### PR TITLE
Allow operator to create rolebindings

### DIFF
--- a/chart/load-balancer-operator/templates/rbac.yaml
+++ b/chart/load-balancer-operator/templates/rbac.yaml
@@ -14,6 +14,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - delete
   - update
 - apiGroups:
@@ -23,6 +24,7 @@ rules:
   verbs:
   - create
   - delete
+  - patch
   - get
   - list
   - update

--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -2,6 +2,7 @@
 package srv
 
 import (
+	"context"
 	"fmt"
 
 	"helm.sh/helm/v3/pkg/action"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	rbacapplyv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/helm/pkg/strvals"
@@ -28,7 +30,7 @@ func (s *Server) CreateNamespace(groupID string) error {
 	kc, err := kubernetes.NewForConfig(s.KubeClient)
 
 	if err != nil {
-		s.Logger.Errorln("unable to authenticate against kubernetes cluster")
+		s.Logger.Errorw("unable to authenticate against kubernetes cluster", "error", err)
 		return err
 	}
 
@@ -48,7 +50,33 @@ func (s *Server) CreateNamespace(groupID string) error {
 	_, err = kc.CoreV1().Namespaces().Apply(s.Context, &apSpec, metav1.ApplyOptions{FieldManager: "loadbalanceroperator"})
 
 	if err != nil {
-		s.Logger.Errorf("unable to create namespace: %s", err)
+		s.Logger.Errorw("unable to create namespace", "error", err)
+		return err
+	}
+
+	if err := attachRoleBinding(s.Context, kc, groupID); err != nil {
+		s.Logger.Errorw("unable to attach namespace manager rolebinding to namespace", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func attachRoleBinding(ctx context.Context, client *kubernetes.Clientset, namespace string) error {
+	apSpec := rbacapplyv1.RoleBindingApplyConfiguration{
+		RoleRef: &rbacapplyv1.RoleRefApplyConfiguration{Kind: strPt("ClusterRole"), Name: strPt("cluster-admin")},
+		Subjects: []rbacapplyv1.SubjectApplyConfiguration{
+			{
+				Kind:      strPt("ServiceAccount"),
+				Name:      strPt("load-balancer-operator"),
+				Namespace: &namespace,
+			},
+		},
+	}
+
+	_, err := client.RbacV1().RoleBindings(namespace).Apply(ctx, &apSpec, metav1.ApplyOptions{FieldManager: "loadbalanceroperator"})
+
+	if err != nil {
 		return err
 	}
 
@@ -131,4 +159,8 @@ func (s *Server) newHelmClient(namespace string) (*action.Configuration, error) 
 	}
 
 	return config, nil
+}
+
+func strPt(s string) *string {
+	return &s
 }

--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -34,12 +34,10 @@ func (s *Server) CreateNamespace(groupID string) error {
 		return err
 	}
 
-	kind := "Namespace"
-	apiv := "v1"
 	apSpec := applyv1.NamespaceApplyConfiguration{
 		TypeMetaApplyConfiguration: applymetav1.TypeMetaApplyConfiguration{
-			Kind:       &kind,
-			APIVersion: &apiv,
+			Kind:       strPt("Namespace"),
+			APIVersion: strPt("v1"),
 		},
 		ObjectMetaApplyConfiguration: &applymetav1.ObjectMetaApplyConfiguration{
 			Name: &groupID,
@@ -64,6 +62,13 @@ func (s *Server) CreateNamespace(groupID string) error {
 
 func attachRoleBinding(ctx context.Context, client *kubernetes.Clientset, namespace string) error {
 	apSpec := rbacapplyv1.RoleBindingApplyConfiguration{
+		ObjectMetaApplyConfiguration: &applymetav1.ObjectMetaApplyConfiguration{
+			Name: strPt("load-balancer-operator-admin"),
+		},
+		TypeMetaApplyConfiguration: applymetav1.TypeMetaApplyConfiguration{
+			Kind:       strPt("RoleBinding"),
+			APIVersion: strPt("rbac.authorization.k8s.io/v1"),
+		},
 		RoleRef: &rbacapplyv1.RoleRefApplyConfiguration{Kind: strPt("ClusterRole"), Name: strPt("cluster-admin")},
 		Subjects: []rbacapplyv1.SubjectApplyConfiguration{
 			{


### PR DESCRIPTION
PR adds the ability for the load-balancer-operator to create a role binding in tenant namespaces that will allow it to control all things within that namespace.

It also fixes permissions in the helm chart RBAC and does some minor logging cleanup within related app functions.