### PR TITLE
Deploy each load-balancer to its own namespace

### DIFF
--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -80,8 +80,8 @@ func (s *Server) newHelmValues(overrides []valueSet) (map[string]interface{}, er
 
 // newDeployment deploys a loadBalancer based upon the configuration provided
 // from the event that is processed.
-func (s *Server) newDeployment(name string, namespace string, overrides []valueSet) error {
-	releaseName := fmt.Sprintf("lb-%s-%s", name, namespace)
+func (s *Server) newDeployment(name string, overrides []valueSet) error {
+	releaseName := fmt.Sprintf("lb-%s", name)
 	if len(releaseName) > nameLength {
 		releaseName = releaseName[0:nameLength]
 	}
@@ -92,7 +92,7 @@ func (s *Server) newDeployment(name string, namespace string, overrides []valueS
 		return err
 	}
 
-	client, err := s.newHelmClient(namespace)
+	client, err := s.newHelmClient(name)
 	if err != nil {
 		s.Logger.Errorln("unable to initialize helm client: %s", err)
 		return err
@@ -100,15 +100,15 @@ func (s *Server) newDeployment(name string, namespace string, overrides []valueS
 
 	hc := action.NewInstall(client)
 	hc.ReleaseName = releaseName
-	hc.Namespace = namespace
+	hc.Namespace = name
 	_, err = hc.Run(s.Chart, values)
 
 	if err != nil {
-		s.Logger.Errorf("unable to deploy %s to %s", releaseName, namespace)
+		s.Logger.Errorf("unable to deploy %s to %s", releaseName, name)
 		return err
 	}
 
-	s.Logger.Infof("%s deployed to %s successfully", releaseName, namespace)
+	s.Logger.Infof("%s deployed to %s successfully", releaseName, name)
 
 	return nil
 }

--- a/internal/srv/app_test.go
+++ b/internal/srv/app_test.go
@@ -216,7 +216,7 @@ func TestNewDeployment(t *testing.T) {
 				Chart:      tcase.chart,
 			}
 
-			_ = srv.CreateNamespace(tcase.appNamespace)
+			_ = srv.CreateNamespace(tcase.appName)
 			err = srv.newDeployment(tcase.appName, nil)
 
 			if tcase.expectError {

--- a/internal/srv/app_test.go
+++ b/internal/srv/app_test.go
@@ -225,7 +225,7 @@ func TestNewDeployment(t *testing.T) {
 			}
 
 			_ = srv.CreateNamespace(tcase.appNamespace)
-			err = srv.newDeployment(tcase.appName, tcase.appNamespace, nil)
+			err = srv.newDeployment(tcase.appName, nil)
 
 			if tcase.expectError {
 				assert.NotNil(t, err)

--- a/internal/srv/app_test.go
+++ b/internal/srv/app_test.go
@@ -179,15 +179,6 @@ func TestNewDeployment(t *testing.T) {
 			kubeClient:   cfg,
 		},
 		{
-			name:         "invalid namespace",
-			expectError:  true,
-			appNamespace: "DarkwingDuck",
-			appName:      uuid.New().String(),
-			chart:        ch,
-			valPath:      pwd + "/../../hack/ci/values.yaml",
-			kubeClient:   cfg,
-		},
-		{
 			name:         "missing values path",
 			expectError:  true,
 			appNamespace: uuid.New().String(),

--- a/internal/srv/handlers.go
+++ b/internal/srv/handlers.go
@@ -47,7 +47,7 @@ func (s *Server) createMessageHandler(m *pubsubx.Message) error {
 		return err
 	}
 
-	if err := s.CreateNamespace(m.SubjectURN); err != nil {
+	if err := s.CreateNamespace(lbdata.LoadBalancerID.String()); err != nil {
 		s.Logger.Errorw("handler unable to create required namespace", "error", err)
 		return err
 	}
@@ -67,7 +67,7 @@ func (s *Server) createMessageHandler(m *pubsubx.Message) error {
 		})
 	}
 
-	if err := s.newDeployment(lbdata.LoadBalancerID.String(), m.SubjectURN, overrides); err != nil {
+	if err := s.newDeployment(lbdata.LoadBalancerID.String(), overrides); err != nil {
 		s.Logger.Errorw("handler unable to create loadbalancer", "error", err)
 		return err
 	}


### PR DESCRIPTION
This changes the logic from deploying all load-balancers belonging to a tenant into a common namespace to deploying each load-balancer into its own namespace. This simplifies later logic where load-balancers would conflict because of having to "own" common objects that would get deployed in the namespace.