### PR TITLE
Add load-balancer-operator-managed annotation to generated namespaces

### DIFF
--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -42,7 +42,7 @@ func (s *Server) CreateNamespace(groupID string) (*v1.Namespace, error) {
 		},
 		ObjectMetaApplyConfiguration: &applymetav1.ObjectMetaApplyConfiguration{
 			Name:        &groupID,
-			Annotations: map[string]string{"load-balancer-operator-managed": "true"},
+			Annotations: map[string]string{"com.infratographer.lb-operator/managed": "true"},
 		},
 		Spec:   &applyv1.NamespaceSpecApplyConfiguration{},
 		Status: &applyv1.NamespaceStatusApplyConfiguration{},

--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -9,6 +9,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
@@ -25,13 +26,13 @@ const (
 
 // CreateNamespace creates namespaces for the specified group that is
 // provided in the event received
-func (s *Server) CreateNamespace(groupID string) error {
+func (s *Server) CreateNamespace(groupID string) (*v1.Namespace, error) {
 	s.Logger.Debugf("ensuring namespace %s exists", groupID)
 	kc, err := kubernetes.NewForConfig(s.KubeClient)
 
 	if err != nil {
 		s.Logger.Errorw("unable to authenticate against kubernetes cluster", "error", err)
-		return err
+		return nil, err
 	}
 
 	apSpec := applyv1.NamespaceApplyConfiguration{
@@ -40,24 +41,25 @@ func (s *Server) CreateNamespace(groupID string) error {
 			APIVersion: strPt("v1"),
 		},
 		ObjectMetaApplyConfiguration: &applymetav1.ObjectMetaApplyConfiguration{
-			Name: &groupID,
+			Name:        &groupID,
+			Annotations: map[string]string{"load-balancer-operator-managed": "true"},
 		},
 		Spec:   &applyv1.NamespaceSpecApplyConfiguration{},
 		Status: &applyv1.NamespaceStatusApplyConfiguration{},
 	}
-	_, err = kc.CoreV1().Namespaces().Apply(s.Context, &apSpec, metav1.ApplyOptions{FieldManager: "loadbalanceroperator"})
+	ns, err := kc.CoreV1().Namespaces().Apply(s.Context, &apSpec, metav1.ApplyOptions{FieldManager: "loadbalanceroperator"})
 
 	if err != nil {
 		s.Logger.Errorw("unable to create namespace", "error", err)
-		return err
+		return nil, err
 	}
 
 	if err := attachRoleBinding(s.Context, kc, groupID); err != nil {
 		s.Logger.Errorw("unable to attach namespace manager rolebinding to namespace", "error", err)
-		return err
+		return nil, err
 	}
 
-	return nil
+	return ns, nil
 }
 
 func attachRoleBinding(ctx context.Context, client *kubernetes.Clientset, namespace string) error {

--- a/internal/srv/app_test.go
+++ b/internal/srv/app_test.go
@@ -112,12 +112,14 @@ func TestCreateNamespace(t *testing.T) {
 				KubeClient: tcase.kubeclient,
 			}
 
-			err := srv.CreateNamespace(tcase.appNamespace)
+			ns, err := srv.CreateNamespace(tcase.appNamespace)
 
 			if tcase.expectError {
 				assert.NotNil(t, err)
+				assert.Nil(t, ns)
 			} else {
 				assert.Nil(t, err)
+				assert.Contains(t, ns.Annotations, "load-balancer-operator-managed")
 			}
 		})
 	}
@@ -216,7 +218,7 @@ func TestNewDeployment(t *testing.T) {
 				Chart:      tcase.chart,
 			}
 
-			_ = srv.CreateNamespace(tcase.appName)
+			_, _ = srv.CreateNamespace(tcase.appName)
 			err = srv.newDeployment(tcase.appName, nil)
 
 			if tcase.expectError {

--- a/internal/srv/app_test.go
+++ b/internal/srv/app_test.go
@@ -119,7 +119,7 @@ func TestCreateNamespace(t *testing.T) {
 				assert.Nil(t, ns)
 			} else {
 				assert.Nil(t, err)
-				assert.Contains(t, ns.Annotations, "load-balancer-operator-managed")
+				assert.Contains(t, ns.Annotations, "com.infratographer.lb-operator/managed")
 			}
 		})
 	}

--- a/internal/srv/handlers.go
+++ b/internal/srv/handlers.go
@@ -47,7 +47,7 @@ func (s *Server) createMessageHandler(m *pubsubx.Message) error {
 		return err
 	}
 
-	if err := s.CreateNamespace(lbdata.LoadBalancerID.String()); err != nil {
+	if _, err := s.CreateNamespace(lbdata.LoadBalancerID.String()); err != nil {
 		s.Logger.Errorw("handler unable to create required namespace", "error", err)
 		return err
 	}


### PR DESCRIPTION
Adds annotation to namespaces managed/created by load-balancer-operator

Signed-off-by: Tyler Auerbeck <tylerauerbeck@users.noreply.github.com>