### PR TITLE
Generate managed helm values for loadbalancer, tenant and location IDs

### DIFF
--- a/chart/load-balancer-operator/values.yaml
+++ b/chart/load-balancer-operator/values.yaml
@@ -50,6 +50,12 @@ operator:
       - "changes.*.lb"
       - "events.create.port"
     queue: "my-queue"
+  # these will be overwritten by the operator but are provided here for reference
+  managed:
+    loadBalancerID: ""
+    loadBalancerTenantID: ""
+    loadBalancerLocationID: ""
+
 
 reloader:
   enabled: false

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -107,6 +107,7 @@ func process(ctx context.Context, logger *zap.SugaredLogger) error {
 		Subjects:        viper.GetStringSlice("nats.subjects"),
 		StreamName:      viper.GetString("nats.stream-name"),
 		ValuesPath:      viper.GetString("chart-values-path"),
+		Locations:       viper.GetStringSlice("locations"),
 	}
 
 	if err := server.Run(cx); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -155,6 +155,7 @@ require (
 
 require (
 	github.com/labstack/echo/v4 v4.10.2
+	golang.org/x/exp v0.0.0-20221230185412-738e83a70c30
 	sigs.k8s.io/controller-runtime v0.14.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -720,6 +720,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221230185412-738e83a70c30 h1:m9O6OTJ627iFnN2JIWfdqlZCzneRO6EEBsHXI25P8ws=
+golang.org/x/exp v0.0.0-20221230185412-738e83a70c30/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/srv/load-balancer.go
+++ b/internal/srv/load-balancer.go
@@ -55,9 +55,10 @@ func (s *Server) processLoadBalancerChange(msg pubsubx.ChangeMessage) error {
 }
 
 func (s *Server) processLoadBalancerChangeCreate(msg pubsubx.ChangeMessage) error {
-	lbID := msg.SubjectID.String()
+	// lbID := msg.SubjectID.String()
+	lb := s.newLoadBalancer(msg.SubjectID, msg.AdditionalSubjectIDs)
 
-	if err := s.newDeployment(lbID, nil); err != nil {
+	if err := s.newDeployment(lb); err != nil {
 		s.Logger.Errorw("handler unable to create loadbalancer", "error", err)
 		return err
 	}

--- a/internal/srv/server.go
+++ b/internal/srv/server.go
@@ -28,6 +28,7 @@ type Server struct {
 	Chart           *chart.Chart
 	ChartPath       string
 	ValuesPath      string
+	Locations       []string
 }
 
 // Run will start the server queue connections and healthcheck endpoints

--- a/internal/srv/types.go
+++ b/internal/srv/types.go
@@ -1,6 +1,10 @@
 package srv
 
-import "errors"
+import (
+	"errors"
+
+	"go.infratographer.com/x/gidx"
+)
 
 const (
 
@@ -18,3 +22,9 @@ var (
 	errUnknownEventType = errors.New("unknown event type")
 	// errUnableToProcess  = errors.New("unable to process message")
 )
+
+type loadBalancer struct {
+	loadBalancerID         gidx.PrefixedID
+	loadBalancerTenantID   gidx.PrefixedID
+	loadBalancerLocationID gidx.PrefixedID
+}


### PR DESCRIPTION
- Allows the operator to provide helm values under `operator.managed` that can be used by the deployed chart
- Currently provides values for
  - loadBalancerID
  - loadBalancerTenantID
  - loadBalancerLocationID