### PR TITLE
Set generated helm values to base64 value with no padding

### DIFF
--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -136,7 +136,6 @@ func (s *Server) newHelmValues(lb *loadBalancer) (map[string]interface{}, error)
 	additionalValues := generateLBHelmValues(lb)
 
 	for _, override := range additionalValues {
-		// or := base64.URLEncoding.EncodeToString([]byte(override))
 		if err := strvals.ParseInto(override, values); err != nil {
 			s.Logger.Errorw("unable to parse values", "error", err)
 			return nil, err

--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -4,6 +4,7 @@ package srv
 import (
 	"context"
 	"crypto/md5"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"reflect"
@@ -49,10 +50,10 @@ func (s *Server) removeNamespace(ns string) error {
 
 // CreateNamespace creates namespaces for the specified group that is
 // provided in the event received
-func (s *Server) CreateNamespace(name string, hash string) (*v1.Namespace, error) {
+func (s *Server) CreateNamespace(hash string, encoded string) (*v1.Namespace, error) {
 	s.Logger.Debugf("ensuring namespace %s exists", hash)
 
-	if !checkNameLength(hash) || !checkNameLength(name) {
+	if !checkNameLength(hash) || !checkNameLength(encoded) {
 		return nil, errInvalidObjectNameLength
 	}
 
@@ -70,8 +71,8 @@ func (s *Server) CreateNamespace(name string, hash string) (*v1.Namespace, error
 		},
 		ObjectMetaApplyConfiguration: &applymetav1.ObjectMetaApplyConfiguration{
 			Name: &hash,
-			Annotations: map[string]string{"com.infratographer.lb-operator/managed": "true",
-				"com.infratographer.lb-operator/lb-id": name},
+			Labels: map[string]string{"com.infratographer.lb-operator/managed": "true",
+				"com.infratographer.lb-operator/lb-id": encoded},
 		},
 		Spec:   &applyv1.NamespaceSpecApplyConfiguration{},
 		Status: &applyv1.NamespaceStatusApplyConfiguration{},
@@ -135,6 +136,7 @@ func (s *Server) newHelmValues(lb *loadBalancer) (map[string]interface{}, error)
 	additionalValues := generateLBHelmValues(lb)
 
 	for _, override := range additionalValues {
+		// or := base64.URLEncoding.EncodeToString([]byte(override))
 		if err := strvals.ParseInto(override, values); err != nil {
 			s.Logger.Errorw("unable to parse values", "error", err)
 			return nil, err
@@ -181,8 +183,9 @@ func (s *Server) removeDeployment(name string) error {
 // from the event that is processed.
 func (s *Server) newDeployment(lb *loadBalancer) error {
 	n := hashName(lb.loadBalancerID.String())
+	enc := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(lb.loadBalancerID.String()))
 
-	if _, err := s.CreateNamespace(lb.loadBalancerID.String(), n); err != nil {
+	if _, err := s.CreateNamespace(n, enc); err != nil {
 		s.Logger.Errorw("unable to create namespace", "error", err)
 		return err
 	}
@@ -257,7 +260,9 @@ func generateLBHelmValues(lb *loadBalancer) []string {
 
 	v := reflect.ValueOf(lb).Elem()
 	for i := 0; i < v.NumField(); i++ {
-		val := fmt.Sprintf("%s.%s=%s", managedHelmKeyPrefix, v.Type().Field(i).Name, v.Field(i))
+		field := fmt.Sprintf("%s", v.Field(i))
+		// fmt.Println(base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(field)))
+		val := fmt.Sprintf("%s.%s=%s", managedHelmKeyPrefix, v.Type().Field(i).Name, base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(field)))
 		vals = append(vals, val)
 	}
 

--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -261,7 +261,6 @@ func generateLBHelmValues(lb *loadBalancer) []string {
 	v := reflect.ValueOf(lb).Elem()
 	for i := 0; i < v.NumField(); i++ {
 		field := fmt.Sprintf("%s", v.Field(i))
-		// fmt.Println(base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(field)))
 		val := fmt.Sprintf("%s.%s=%s", managedHelmKeyPrefix, v.Type().Field(i).Name, base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(field)))
 		vals = append(vals, val)
 	}

--- a/internal/srv/handlers.go
+++ b/internal/srv/handlers.go
@@ -10,11 +10,6 @@ import (
 	"go.infratographer.com/x/pubsubx"
 )
 
-type valueSet struct {
-	helmKey string
-	value   string
-}
-
 func (s *Server) messageRouter(m *nats.Msg) {
 	subjString, data := getSubject(m)
 


### PR DESCRIPTION
- Sets generated helm values as a base64 value with no padding to appease the laws of Kube

The problem that was being encountered is that the ID's that are generated by `gidx` have the possibility of ending in `-` and `_`. This conflicts with limitations on Kubernetes labels where they can only begin and end in alphanumeric characters. To get around this, we need to makes these values available as a URL safe base64 encoded string, specifically one with no padding (to avoid trailing `=`).