### PR TITLE
Update operator chart to work with new configurations

### DIFF
--- a/chart/load-balancer-operator/templates/configmap.yaml
+++ b/chart/load-balancer-operator/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-config
+data:
+  LOADBALANCEROPERATOR_EVENTS_SUBSCRIBER_PREFIX: "{{ .Values.operator.events.topicPrefix }}"
+  LOADBALANCEROPERATOR_EVENTS_SUBSCRIBER_URL: "{{ .Values.operator.events.connectionURL }}"
+  LOADBALANCEROPERATOR_EVENTS_QUEUEGROUP: "{{ .Values.operator.events.queueGroup }}"
+  LOADBALANCEROPERATOR_API_ENDPOINT: "{{ .Values.operator.api.endpoint }}"
+  LOADBALANCEROPERATOR_CHART_PATH: "{{ .Values.operator.chart.chartPath }}"
+  LOADBALANCEROPERATOR_CHART_VALUE_PATH: "{{ .Values.operator.chart.valuesPath }}"
+  LOADBALANCEROPERATOR_OIDC: "{{ .Values.operator.api.oidc.enabled }}"
+  LOADBALANCEROPERATOR_OIDC_AUDIENCE: "{{ .Values.operator.api.oidc.audience }}"
+  LOADBALANCEROPERATOR_OIDC_ISSUER: "{{ .Values.operator.api.oidc.issuer }}"

--- a/chart/load-balancer-operator/templates/deploy-chart.yaml
+++ b/chart/load-balancer-operator/templates/deploy-chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lb-chart
+data:
+  values.yaml: |
+{{ toYaml .Values.operator.chart.chartValues | indent 4}}
+binaryData:
+  chart.tgz: {{ .Values.operator.chart.chartBinaryData }}

--- a/chart/load-balancer-operator/templates/deployment.yaml
+++ b/chart/load-balancer-operator/templates/deployment.yaml
@@ -40,23 +40,16 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.operator.extraEnvVars }}
           env:
-            - name: LOADBALANCEROPERATOR_CHART_PATH
-              value: "/chart.tgz"
-            - name: LOADBALANCEROPERATOR_NATS_URL
-              value: "{{ .Values.operator.events.connectionURL }}"
-            - name: LOADBALANCEROPERATOR_NATS_STREAM_NAME
-              value: "{{ .Values.operator.events.queue | default "loadbalanceroperator" }}"
-            - name: LOADBALANCEROPERATOR_NATS_SUBJECT_PREFIX
-              value: "{{ .Values.operator.events.subjectPrefix }}"
-          {{- if .Values.operator.events.auth.secretName }}
-            - name: LOADBALANCEROPERATOR_NATS_CREDS_FILE
-              value: "/creds"
-          {{- end -}}
-          {{ if .Values.operator.chart.valuesPath }}
-            - name: LOADBALANCEROPERATOR_CHART_VALUES_PATH
-              value: "/lb-values.yaml"
+          {{- range .Values.operator.extraEnvVars }}
+            name: {{ .name }}
+            value: {{ .value }}
           {{- end }}
+          {{- end }}
+          envFrom:
+          - configMapRef:
+              name: operator-config
           {{- if .Values.operator.securityContext }}
           securityContext:
             {{- toYaml .Values.operator.securityContext | nindent 12 }}
@@ -65,14 +58,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - process
-          {{- range .Values.operator.events.subjects }}
-            - --nats-subjects={{ . }}
+          {{- range .Values.operator.events.topics }}
+            - --event-topics={{ . }}
           {{- end }}
-          {{- range .Values.operator.chart.valuesCPUFlag }}
-            - --helm-cpu-flag={{ . }}
-          {{- end }}
-          {{- range .Values.operator.chart.valuesMemoryFlag }}
-            - --helm-memory-flag={{ . }}
+          {{- range .Values.operator.events.locations }}
+            - --event-locations={{ . }}
           {{- end }}
           ports:
             - name: hc
@@ -81,10 +71,6 @@ spec:
           livenessProbe:
             httpGet:
               path: /livez
-              port: hc
-          readinessProbe:
-            httpGet:
-              path: /readyz
               port: hc
           volumeMounts:
             - name: chart-config
@@ -115,20 +101,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-      {{- if ne .Values.operator.chart.valuesPath "" }}
-        - name: chart-values-path
-          configMap:
-            name: "{{ .Values.operator.chart.configMapName }}"
-            items:
-              - key: values.yaml
-                path: values.yaml
-      {{- end }}
-        - name: chart-path
-          configMap:
-            name: "{{ .Values.operator.chart.configMapName }}"
-            items:
-              - key: chart.yaml
-                path: chart.yaml
         {{- if .Values.operator.events.auth.secretName  }}
         - name: events-creds
           secret:

--- a/chart/load-balancer-operator/values.yaml
+++ b/chart/load-balancer-operator/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: ghcr.io/infratographer/load-balancer-operator
   pullPolicy: IfNotPresent
-  tag: "v0.0.3"
+  tag: "v0.1.0"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -26,36 +26,35 @@ operator:
   replicas: 1
   extraLabels: {}
   extraAnnotations: {}
-  extraEnvVars: {}
+  extraEnvVars: []
+#    - name: thing
+#      value: otherthing 
   resources: {}
   podSecurityContext: {}
   securityContext: {}
+  api:
+    endpoint: "https://localhost:7608/query"
+    oidc:
+      enabled: false
+      audience: ""
+      issuer: ""
   chart:
     configMapName: "lb-chart"
     chartPath: "/chart.tgz"
     valuesPath: "/events-creds"
-    valuesMemoryFlag:
-      - resources.limits.memory
-      - resources.requests.memory
-    valuesCPUFlag:
-      - resources.limits.cpu
-      - resources.requests.cpu
+    chartValues: ""
+    chartBinaryData: ""
   events:
-    connectionURL: "my-events-cluster.example.com:4222"
+    queueGroup: "my-queue-group"
+    connectionURL: "nats://my-events-cluster.example.com:4222"
     auth:
-      secretName: "events-creds"
+      secretName: ""
       credsPath: "/creds"
-    subjectPrefix: "com.infratographer"
-    subjects:
+    topicPrefix: "com.infratographer"
+    topics:
       - "changes.*.lb"
       - "events.create.port"
-    queue: "my-queue"
-  # these will be overwritten by the operator but are provided here for reference
-  managed:
-    loadBalancerID: ""
-    loadBalancerTenantID: ""
-    loadBalancerLocationID: ""
-
+    locations: []
 
 reloader:
   enabled: false


### PR DESCRIPTION
This updates the operator chart to work with the recent refactor.

This adds the ability to:
- Specify broker specific variables (i.e. `LOADBALANCEROPERATOR_EVENTS_SUBSCRIBER_NATS_CREDSFILE`) via `operator.extraEnvVars`
- Configure the LB API that the operator runs against via `operator.api.<variables>`
- Configure LB API OIDC via `operator.api.oidc`. This is set to false by default.
- Changes nats specific `subject` terminology to use the more generic `topic` terminology

Adds the ability to specify the values and chart deployed by the operator from the core chart. Previously this was done by sub charting the operator chart and then adding a separate template that contains these values. This can now be done by setting the `operator.chart.chartValues` and `operator.chartBinaryData` values. 