### PR TITLE
Fix Dockerfile to use goreleaser generated binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,7 @@
-FROM golang:1.20 as builder
-
-# Create and change to the app directory.
-WORKDIR /app
-
-# Retrieve application dependencies using go modules.
-# Allows container builds to reuse downloaded dependencies.
-COPY go.* ./
-RUN go mod download
-
-# Copy local code to the container image.
-COPY . ./
-
-# Build the binary.
-# -mod=readonly ensures immutable go.mod and go.sum in container builds.
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o loadbalanceroperator 
-
 FROM gcr.io/distroless/static
 
-# Copy the binary to the production image from the builder stage.
-COPY --from=builder /app/loadbalanceroperator /loadbalanceroperator
+# Copy the binary that goreleaser built
+COPY load-balancer-operator /load-balancer-operator
 
-ENTRYPOINT ["/loadbalanceroperator"]
+ENTRYPOINT ["/load-balancer-operator"]
 CMD ["process"]


### PR DESCRIPTION
Update Dockerfile to use goreleaser generated binary