### PR TITLE
Add ability to specify extra  for the operator deployment

### DIFF
--- a/chart/load-balancer-operator/templates/deployment.yaml
+++ b/chart/load-balancer-operator/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" . }}-config
+          {{- if .Values.operator.extraEnvFrom }}
+            {{- toYaml .Values.operator.extraEnvFrom | nindent 12 }}
+         {{- end }}
           {{- if .Values.operator.securityContext }}
           securityContext:
             {{- toYaml .Values.operator.securityContext | nindent 12 }}

--- a/chart/load-balancer-operator/values.yaml
+++ b/chart/load-balancer-operator/values.yaml
@@ -26,6 +26,7 @@ operator:
   replicas: 1
   extraLabels: []
   extraAnnotations: []
+  extraEnvFrom: {}
   extraEnvVars: []
   #    - name: LOADBALANCEROPERATOR_EVENTS_SUBSCRIBER_NATS_CREDSFILE
   #      value: "/creds"


### PR DESCRIPTION
Adds ability to the helm chart for specifying additional envFrom values, which will allow for pulling in env variables from secrets containing things like OIDC Client secrets.