### PR TITLE
Add ability to specify different change and event topics in helm chart

### DIFF
--- a/chart/load-balancer-operator/templates/deployment.yaml
+++ b/chart/load-balancer-operator/templates/deployment.yaml
@@ -61,8 +61,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - process
-          {{- range .Values.operator.events.topics }}
+          {{- range .Values.operator.events.eventTopics }}
             - --event-topics={{ . }}
+          {{- end }}
+          {{- range .Values.operator.events.changeTopics }}
+            - --change-topics={{ . }}
           {{- end }}
           {{- range .Values.operator.events.locations }}
             - --event-locations={{ . }}

--- a/chart/load-balancer-operator/values.yaml
+++ b/chart/load-balancer-operator/values.yaml
@@ -47,9 +47,11 @@ operator:
       secretName: ""
       credsPath: "/creds"
     topicPrefix: "com.infratographer"
-    topics:
-      - "changes.*.lb"
-      - "events.create.port"
+    changeTopics:
+      - "*.lb"
+      - "*.port"
+    eventTopics: []
+    
     locations: []
 
 reloader:


### PR DESCRIPTION
After adding the ability to specify different sets of change and event topics to the operator, we need to enable this in the helm chart.