### PR TITLE
Fixes misconfigured env var

### DIFF
--- a/chart/load-balancer-operator/templates/config.yaml
+++ b/chart/load-balancer-operator/templates/config.yaml
@@ -10,4 +10,4 @@ data:
   LOADBALANCEROPERATOR_EVENTS_QUEUEGROUP: "{{ .Values.operator.events.queueGroup }}"
   LOADBALANCEROPERATOR_API_ENDPOINT: "{{ .Values.operator.api.endpoint }}"
   LOADBALANCEROPERATOR_CHART_PATH: "/chart.tgz"
-  LOADBALANCEROPERATOR_CHART_VALUE_PATH: "/lb-values.yaml"
+  LOADBALANCEROPERATOR_CHART_VALUES_PATH: "/lb-values.yaml"


### PR DESCRIPTION
Adds missing `S` to `LOADBALANCEROPERATOR_CHART_VALUES_PATH`