### PR TITLE
Fix loadbalancer deletes

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -111,7 +111,6 @@ func process(ctx context.Context, logger *zap.SugaredLogger) error {
 	}
 
 	server := &srv.Server{
-		// APIClient:        lbapi.NewClient(viper.GetString("api-endpoint")),
 		Echo:             eSrv,
 		Chart:            chart,
 		Context:          cx,
@@ -128,15 +127,11 @@ func process(ctx context.Context, logger *zap.SugaredLogger) error {
 	// init lbapi client
 	if config.AppConfig.OIDC.ClientID != "" {
 		oauthHTTPClient := oauth2x.NewClient(ctx, oauth2x.NewClientCredentialsTokenSrc(ctx, config.AppConfig.OIDC))
-		server.APIClient = lbapi.NewClient(determineEndpoint(viper.GetString("api-endpoint"), viper.GetString("supergraph-endpoint")),
-			lbapi.WithHTTPClient(oauthHTTPClient),
-		)
-		server.IPAMClient = ipamclient.NewClient(determineEndpoint(viper.GetString("ipam-endpoint"), viper.GetString("supergraph-endpoint")),
-			ipamclient.WithHTTPClient(oauthHTTPClient),
-		)
+		server.APIClient = lbapi.NewClient(viper.GetString("supergraph-endpoint"), lbapi.WithHTTPClient(oauthHTTPClient))
+		server.IPAMClient = ipamclient.NewClient(viper.GetString("supergraph-endpoint"), ipamclient.WithHTTPClient(oauthHTTPClient))
 	} else {
-		server.APIClient = lbapi.NewClient(determineEndpoint(viper.GetString("api-endpoint"), viper.GetString("supergraph-endpoint")))
-		server.IPAMClient = ipamclient.NewClient(determineEndpoint(viper.GetString("ipam-endpoint"), viper.GetString("supergraph-endpoint")))
+		server.APIClient = lbapi.NewClient(viper.GetString("supergraph-endpoint"))
+		server.IPAMClient = ipamclient.NewClient(viper.GetString("supergraph-endpoint"))
 	}
 
 	if err := server.Run(cx); err != nil {

--- a/internal/srv/handlers.go
+++ b/internal/srv/handlers.go
@@ -20,6 +20,8 @@ func (s *Server) locationCheck(i gidx.PrefixedID) bool {
 }
 
 func (s *Server) processEvent(messages <-chan *message.Message) {
+	var lb *loadBalancer
+
 	for msg := range messages {
 		s.Logger.Infof("received event message: %s, payload: %s\n", msg.UUID, string(msg.Payload))
 
@@ -30,21 +32,27 @@ func (s *Server) processEvent(messages <-chan *message.Message) {
 		}
 
 		if slices.ContainsFunc(m.AdditionalSubjectIDs, s.locationCheck) || len(s.Locations) == 0 {
-			lb, err := s.newLoadBalancer(m.SubjectID, m.AdditionalSubjectIDs)
-			if err != nil {
-				s.Logger.Errorw("unable to initialize loadbalancer", "error", err, "messageID", msg.UUID)
-				msg.Nack()
+			if m.EventType == string("ip-address.unassigned") {
+				lb = &loadBalancer{loadBalancerID: m.SubjectID, lbData: nil, lbType: typeLB}
+			} else {
+				lb, err = s.newLoadBalancer(m.SubjectID, m.AdditionalSubjectIDs)
+				if err != nil {
+					s.Logger.Errorw("unable to initialize loadbalancer", "error", err, "messageID", msg.UUID)
+					msg.Nack()
+				}
 			}
 
 			if lb.lbType != typeNoLB {
 				switch {
-				case m.EventType == "ip-address.assigned" || m.EventType == "ip-address.unassigned":
+				case m.EventType == "ip-address.assigned":
 					s.Logger.Debugw("ip address processed. updating loadbalancer", "loadbalancer", lb.loadBalancerID.String())
 
 					if err := s.updateDeployment(lb); err != nil {
 						s.Logger.Errorw("unable to update loadbalancer", "error", err, "messageID", msg.UUID, "loadbalancer", lb.loadBalancerID.String())
 						msg.Nack()
 					}
+				case m.EventType == "ip-address.unassigned":
+					s.Logger.Debugw("ip address unassigned. updating loadbalancer", "loadbalancer", lb.loadBalancerID.String())
 				default:
 					s.Logger.Debugw("unknown event", "loadbalancer", lb.loadBalancerID.String(), "event", m.EventType)
 				}


### PR DESCRIPTION
- Because we're now doing lookups for each load balancer event, deletes were failing. This is because when an object is deleted from the API, it is immediately removed. So by the time the operator goes to do a lookup, it is already gone.