### PR TITLE
Create wrapper for helm install/upgrade

### DIFF
--- a/internal/srv/changes.go
+++ b/internal/srv/changes.go
@@ -1,7 +1,13 @@
 package srv
 
+import "context"
+
 func (s *Server) processLoadBalancerChangeCreate(lb *loadBalancer) error {
-	if err := s.newDeployment(lb); err != nil {
+	// if err := s.newDeployment(lb); err != nil {
+	// 	return err
+	// }
+
+	if err := s.createDeployment(context.TODO(), lb); err != nil {
 		return err
 	}
 
@@ -17,7 +23,11 @@ func (s *Server) processLoadBalancerChangeDelete(lb *loadBalancer) error {
 }
 
 func (s *Server) processLoadBalancerChangeUpdate(lb *loadBalancer) error {
-	if err := s.updateDeployment(lb); err != nil {
+	// if err := s.updateDeployment(lb); err != nil {
+	// 	return err
+	// }
+
+	if err := s.createDeployment(context.TODO(), lb); err != nil {
 		return err
 	}
 

--- a/internal/srv/changes.go
+++ b/internal/srv/changes.go
@@ -3,10 +3,6 @@ package srv
 import "context"
 
 func (s *Server) processLoadBalancerChangeCreate(lb *loadBalancer) error {
-	// if err := s.newDeployment(lb); err != nil {
-	// 	return err
-	// }
-
 	if err := s.createDeployment(context.TODO(), lb); err != nil {
 		return err
 	}
@@ -23,10 +19,6 @@ func (s *Server) processLoadBalancerChangeDelete(lb *loadBalancer) error {
 }
 
 func (s *Server) processLoadBalancerChangeUpdate(lb *loadBalancer) error {
-	// if err := s.updateDeployment(lb); err != nil {
-	// 	return err
-	// }
-
 	if err := s.createDeployment(context.TODO(), lb); err != nil {
 		return err
 	}

--- a/internal/srv/changes_test.go
+++ b/internal/srv/changes_test.go
@@ -66,6 +66,8 @@ func (suite *srvTestSuite) TestProcessLoadBalancerChangeCreate() { //nolint:gove
 		{
 			name:           "invalid loadbalancer - long name",
 			expectedErrors: []error{errInvalidObjectNameLength},
+			chart:          ch,
+			cfg:            suite.Kubeenv.Config,
 			msg: pubsubx.ChangeMessage{
 				EventType: "create",
 				SubjectID: "loadbal-reallyreallyreallyreallyreallyreallylongreallylong",


### PR DESCRIPTION
A common error we see is around helm install / upgrades attempting to take action on a release that already exists. Helm itself provides a `helm upgrade --install` command, which under the covers is just logic to check if a release exists and then to an upgrade if it does. This replicates this  logic by checking to see if a release exists and then taking the appropriate install/upgrade action