### PR TITLE
Handle no deployed helm release on ip address assignment

### DIFF
--- a/internal/srv/events.go
+++ b/internal/srv/events.go
@@ -1,3 +1,16 @@
 package srv
 
-//TODO: stub in event handlers
+import "context"
+
+func (s *Server) processLoadBalancerEventUpdate(lb *loadBalancer) error {
+	deployed, err := s.hasDeployment(context.TODO(), lb)
+	if err != nil {
+		return err
+	}
+
+	if deployed {
+		return s.updateDeployment(lb)
+	}
+
+	return nil
+}

--- a/internal/srv/handlers.go
+++ b/internal/srv/handlers.go
@@ -51,7 +51,7 @@ func (s *Server) processEvent(messages <-chan *message.Message) {
 				case m.EventType == "ip-address.assigned":
 					s.Logger.Debugw("ip address processed. updating loadbalancer", "loadbalancer", lb.loadBalancerID.String())
 
-					if err := s.updateDeployment(lb); err != nil {
+					if err := s.processLoadBalancerEventUpdate(lb); err != nil {
 						s.Logger.Errorw("unable to update loadbalancer", "error", err, "messageID", msg.UUID, "loadbalancer", lb.loadBalancerID.String())
 						msg.Nack()
 					}


### PR DESCRIPTION
For delayed events from ipam, handle the case where the loadbalancer events from haproxy-provider to update the deployment ip address fails due to the deployment no longer existing.