### PR TITLE
Update naming used for ports; Specify dedicated port for metrics

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -40,6 +40,10 @@ var (
 	processDevMode bool
 )
 
+const (
+	DefaultLBMetricsPort = 29782
+)
+
 func init() {
 	// only available as a CLI arg because it shouldn't be something that could accidentially end up in a config file or env var
 	processCmd.Flags().BoolVar(&processDevMode, "dev", false, "dev mode: disables all auth checks, pretty logging, etc.")
@@ -76,6 +80,9 @@ func init() {
 
 	processCmd.PersistentFlags().String("helm-serviceport-key", "service.ports", "key to use for injecting port values for service into chart")
 	viperx.MustBindFlag(viper.GetViper(), "helm-serviceport-key", processCmd.PersistentFlags().Lookup("helm-serviceport-key"))
+
+	processCmd.PersistentFlags().Int("loadbalancer-metrics-port", DefaultLBMetricsPort, "port to expose deployed load balancer metrics on")
+	viperx.MustBindFlag(viper.GetViper(), "loadbalancer-metrics-port", processCmd.PersistentFlags().Lookup("loadbalancer-metrics-port"))
 
 	rootCmd.AddCommand(processCmd)
 }
@@ -122,6 +129,7 @@ func process(ctx context.Context, logger *zap.SugaredLogger) error {
 		SubscriberConfig: config.AppConfig.Events.Subscriber,
 		ValuesPath:       viper.GetString("chart-values-path"),
 		Locations:        viper.GetStringSlice("event-locations"),
+		MetricsPort:      viper.GetInt("loadbalancer-metrics-port"),
 
 		ContainerPortKey: viper.GetString("helm-containerport-key"),
 		ServicePortKey:   viper.GetString("helm-serviceport-key"),

--- a/internal/srv/helm.go
+++ b/internal/srv/helm.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
@@ -37,9 +38,13 @@ func (v helmvalues) generateLBHelmVals(lb *loadBalancer, s *Server) {
 	var cport, sport []interface{}
 
 	for _, port := range lb.lbData.LoadBalancer.Ports.Edges {
-		cport = append(cport, map[string]interface{}{"name": port.Node.Name, "containerPort": port.Node.Number})
-		sport = append(sport, map[string]interface{}{"name": port.Node.Name, "port": port.Node.Number})
+		cport = append(cport, map[string]interface{}{"name": "p" + strconv.Itoa(int(port.Node.Number)), "containerPort": port.Node.Number})
+		sport = append(sport, map[string]interface{}{"name": "p" + strconv.Itoa(int(port.Node.Number)), "port": port.Node.Number})
 	}
+
+	// add metrics port
+	cport = append(cport, map[string]interface{}{"name": "infra9-metrics", "containerPort": s.MetricsPort})
+	sport = append(sport, map[string]interface{}{"name": "infra9-metrics", "port": s.MetricsPort})
 
 	if cport != nil {
 		if cports, err := json.Marshal(cport); err != nil {

--- a/internal/srv/server.go
+++ b/internal/srv/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	Locations        []string
 	ServicePortKey   string
 	ContainerPortKey string
+	MetricsPort      int
 }
 
 // Run will start the server queue connections and healthcheck endpoints


### PR DESCRIPTION
- This PR updates the naming used for ports as using the `name` field had the potential to to cause issues with kube naming limitations
- Also adds the ability to specify a dedicated port that will be used for metrics