### PR TITLE
Shorten managed loadBalancer helm values

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -118,12 +118,13 @@ func process(ctx context.Context, logger *zap.SugaredLogger) error {
 		logger.Desugar(),
 		echox.ConfigFromViper(viper.GetViper()),
 		versionx.BuildDetails(),
+		echox.WithLoggingSkipper(echox.SkipDefaultEndpoints),
 	)
 	if err != nil {
 		logger.Fatal("failed to initialize new server", zap.Error(err))
 	}
 
-	conn, err := events.NewConnection(config.AppConfig.Events)
+	conn, err := events.NewConnection(config.AppConfig.Events, events.WithLogger(logger))
 	if err != nil {
 		logger.Fatalw("failed to create new events connection", "error", err)
 	}

--- a/internal/srv/helm.go
+++ b/internal/srv/helm.go
@@ -25,13 +25,13 @@ const (
 
 func (v helmvalues) generateLBHelmVals(lb *loadBalancer, s *Server) {
 	// add loadbalancer id values
-	v.StringValues = append(v.StringValues, fmt.Sprintf("%s=%s", managedHelmKeyPrefix+".loadBalancerID", lb.loadBalancerID.String()))
-	v.StringValues = append(v.StringValues, fmt.Sprintf("%s=%s", managedHelmKeyPrefix+".loadBalancerIDEnc", hex.EncodeToString([]byte(lb.loadBalancerID.String()))))
+	v.StringValues = append(v.StringValues, fmt.Sprintf("%s=%s", managedHelmKeyPrefix+".lbID", lb.loadBalancerID.String()))
+	v.StringValues = append(v.StringValues, fmt.Sprintf("%s=%s", managedHelmKeyPrefix+".lbIDEnc", hex.EncodeToString([]byte(lb.loadBalancerID.String()))))
 
 	// add IP address if it is available; will be empty if an IP is not yet assigned
 	// while multiple addresses are possible, we only support one for now
 	if len(lb.lbData.LoadBalancer.IPAddresses) > 0 {
-		v.StringValues = append(v.StringValues, fmt.Sprintf("%s=%s", managedHelmKeyPrefix+".loadBalancerIP", lb.lbData.LoadBalancer.IPAddresses[0].IP))
+		v.StringValues = append(v.StringValues, fmt.Sprintf("%s=%s", managedHelmKeyPrefix+".lbIP", lb.lbData.LoadBalancer.IPAddresses[0].IP))
 	}
 
 	// add port values

--- a/internal/srv/helm_test.go
+++ b/internal/srv/helm_test.go
@@ -50,8 +50,8 @@ func (suite *srvTestSuite) TestGenerateLBHelmVals() {
 	opts.generateLBHelmVals(lb, s)
 
 	assert.NotNil(suite.T(), opts.StringValues)
-	assert.Contains(suite.T(), opts.StringValues, managedHelmKeyPrefix+".loadBalancerID="+lb.loadBalancerID.String())
-	assert.Contains(suite.T(), opts.StringValues, managedHelmKeyPrefix+".loadBalancerIDEnc="+hash)
+	assert.Contains(suite.T(), opts.StringValues, managedHelmKeyPrefix+".lbID="+lb.loadBalancerID.String())
+	assert.Contains(suite.T(), opts.StringValues, managedHelmKeyPrefix+".lbIDEnc="+hash)
 
 	assert.NotNil(suite.T(), opts.JSONValues)
 }


### PR DESCRIPTION
helm templating these values downstream is enforcing an 80 character limit in the chart, where a newline is unwantedly added. 