### PR TITLE
Add check for successful install before proceeding to update attempts

### DIFF
--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -269,6 +269,10 @@ func (s *Server) createDeployment(ctx context.Context, lb *loadBalancer) error {
 		if err != nil && !errors.Is(err, driver.ErrReleaseExists) {
 			return err
 		}
+
+		if err == nil {
+			return nil
+		}
 	}
 
 	b := s.BackoffConfig.Start(ctx)


### PR DESCRIPTION
Adds a check during a helm install to see if it was successful prior to moving on to upgrade attempts. The current code was actually triggering an install immediately followed by an upgrade because this check was missing.