### PR TITLE
Fix tracing attribute used for lb id

### DIFF
--- a/internal/srv/handlers.go
+++ b/internal/srv/handlers.go
@@ -39,10 +39,6 @@ func (s *Server) processEvent(msg events.Message[events.EventMessage]) {
 	ctx, span := otel.Tracer(instrumentationName).Start(m.GetTraceContext(s.Context), "processEvent")
 	defer span.End()
 
-	span.SetAttributes(
-		attribute.String("loadbalancer.id", m.SubjectID.String()),
-	)
-
 	if slices.ContainsFunc(m.AdditionalSubjectIDs, s.locationCheck) || len(s.Locations) == 0 {
 		if m.EventType == string("ip-address.unassigned") {
 			lb = &loadBalancer{loadBalancerID: m.SubjectID, lbData: nil, lbType: typeLB}
@@ -52,6 +48,13 @@ func (s *Server) processEvent(msg events.Message[events.EventMessage]) {
 				s.Logger.Errorw("unable to initialize loadbalancer", "error", err, "messageID", msg.ID(), "loadbalancerID", m.SubjectID.String())
 			}
 		}
+
+		span.SetAttributes(
+			attribute.String("loadbalancer.id", lb.loadBalancerID.String()),
+			attribute.String("message.event", m.EventType),
+			attribute.String("message.id", msg.ID()),
+			attribute.String("message.subject", m.SubjectID.String()),
+		)
 
 		if lb != nil && lb.lbType != typeNoLB {
 			switch {
@@ -97,10 +100,6 @@ func (s *Server) processChange(msg events.Message[events.ChangeMessage]) {
 	ctx, span := otel.Tracer(instrumentationName).Start(m.GetTraceContext(s.Context), "processChange")
 	defer span.End()
 
-	span.SetAttributes(
-		attribute.String("loadbalancer.id", m.SubjectID.String()),
-	)
-
 	if slices.ContainsFunc(m.AdditionalSubjectIDs, s.locationCheck) || len(s.Locations) == 0 {
 		if m.EventType == string(events.DeleteChangeType) && m.SubjectID.Prefix() == LBPrefix {
 			lb = &loadBalancer{loadBalancerID: m.SubjectID, lbData: nil, lbType: typeLB}
@@ -110,6 +109,13 @@ func (s *Server) processChange(msg events.Message[events.ChangeMessage]) {
 				s.Logger.Errorw("unable to initialize loadbalancer", "error", err, "messageID", msg.ID(), "subjectID", m.SubjectID.String())
 			}
 		}
+
+		span.SetAttributes(
+			attribute.String("loadbalancer.id", lb.loadBalancerID.String()),
+			attribute.String("message.event", m.EventType),
+			attribute.String("message.id", msg.ID()),
+			attribute.String("message.subject", m.SubjectID.String()),
+		)
 
 		if lb != nil && lb.lbType != typeNoLB {
 			switch {

--- a/internal/srv/handlers.go
+++ b/internal/srv/handlers.go
@@ -56,7 +56,7 @@ func (s *Server) processEvent(msg events.Message[events.EventMessage]) {
 			attribute.String("message.subject", m.SubjectID.String()),
 		)
 
-		if lb != nil && lb.lbType != typeNoLB {
+		if err != nil && lb.lbType != typeNoLB {
 			switch {
 			case m.EventType == "ip-address.assigned":
 				s.Logger.Debugw("ip address processed. updating loadbalancer", "loadbalancer", lb.loadBalancerID.String())
@@ -117,7 +117,7 @@ func (s *Server) processChange(msg events.Message[events.ChangeMessage]) {
 			attribute.String("message.subject", m.SubjectID.String()),
 		)
 
-		if lb != nil && lb.lbType != typeNoLB {
+		if err != nil && lb.lbType != typeNoLB {
 			switch {
 			case m.EventType == string(events.CreateChangeType) && lb.lbType == typeLB:
 				s.Logger.Debugw("creating loadbalancer", "loadbalancer", lb.loadBalancerID.String())


### PR DESCRIPTION
This fixes the attribute used for load balancer id. Currently it is using the subject id, which won't always be the load balancer id. This change used the load balancer id after it is identified from a mix of either the subject id or an id that is contained within additional subjects.