### PR TITLE
Rename module to load-balancer-operator

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 linters-settings:
   goimports:
-    local-prefixes: go.infratographer.com/loadbalanceroperator
+    local-prefixes: go.infratographer.com/load-balancer-operator
 
 linters:
   enable:

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -26,8 +26,8 @@ import (
 	"go.infratographer.com/x/versionx"
 	"go.infratographer.com/x/viperx"
 
-	"go.infratographer.com/loadbalanceroperator/internal/config"
-	"go.infratographer.com/loadbalanceroperator/internal/srv"
+	"go.infratographer.com/load-balancer-operator/internal/config"
+	"go.infratographer.com/load-balancer-operator/internal/srv"
 )
 
 // processCmd represents the base command when called without any subcommands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ import (
 	"go.infratographer.com/x/oauth2x"
 	"go.infratographer.com/x/otelx"
 
-	"go.infratographer.com/loadbalanceroperator/internal/config"
+	"go.infratographer.com/load-balancer-operator/internal/config"
 
 	"go.infratographer.com/x/events"
 	"go.infratographer.com/x/viperx"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.infratographer.com/loadbalanceroperator
+module go.infratographer.com/load-balancer-operator
 
 go 1.20
 

--- a/internal/srv/app_test.go
+++ b/internal/srv/app_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	lbapi "go.infratographer.com/load-balancer-api/pkg/client"
 
-	"go.infratographer.com/loadbalanceroperator/internal/utils"
-	"go.infratographer.com/loadbalanceroperator/internal/utils/mock"
+	"go.infratographer.com/load-balancer-operator/internal/utils"
+	"go.infratographer.com/load-balancer-operator/internal/utils/mock"
 
 	"go.infratographer.com/x/gidx"
 	"go.uber.org/zap"
@@ -21,9 +21,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-var (
-	dummyLBID = "loadbal-lkjasdlfkjasdf"
-)
+var dummyLBID = "loadbal-lkjasdlfkjasdf"
 
 func (suite *srvTestSuite) TestHashLBName() {
 	hash := hashLBName(dummyLBID)

--- a/internal/srv/changes_test.go
+++ b/internal/srv/changes_test.go
@@ -18,8 +18,8 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"k8s.io/client-go/rest"
 
-	"go.infratographer.com/loadbalanceroperator/internal/utils"
-	"go.infratographer.com/loadbalanceroperator/internal/utils/mock"
+	"go.infratographer.com/load-balancer-operator/internal/utils"
+	"go.infratographer.com/load-balancer-operator/internal/utils/mock"
 )
 
 func (suite *srvTestSuite) TestProcessLoadBalancerChangeCreate() { //nolint:govet
@@ -103,8 +103,8 @@ func (suite *srvTestSuite) TestProcessLoadBalancerChangeCreate() { //nolint:gove
 				assert.Nil(suite.T(), err)
 			}
 
-			//TODO: check if the namespace was created
-			//TODO: check if the helm release exists
+			// TODO: check if the namespace was created
+			// TODO: check if the helm release exists
 		})
 	}
 }

--- a/internal/srv/handlers.go
+++ b/internal/srv/handlers.go
@@ -43,7 +43,12 @@ func (s *Server) processEvent(msg events.Message[events.EventMessage]) {
 		} else {
 			lb, err = s.newLoadBalancer(ctx, m.SubjectID, m.AdditionalSubjectIDs)
 			if err != nil {
-				s.Logger.Errorw("unable to initialize loadbalancer", "error", err, "messageID", msg.ID(), "loadbalancerID", m.SubjectID.String())
+				s.Logger.Errorw("unable to initialize loadbalancer",
+					"error", err,
+					"eventType", m.EventType,
+					"messageID", msg.ID(),
+					"subjectID", m.SubjectID.String(),
+					"additionalSubjects", m.AdditionalSubjectIDs)
 			}
 		}
 
@@ -104,7 +109,12 @@ func (s *Server) processChange(msg events.Message[events.ChangeMessage]) {
 		} else {
 			lb, err = s.newLoadBalancer(ctx, m.SubjectID, m.AdditionalSubjectIDs)
 			if err != nil {
-				s.Logger.Errorw("unable to initialize loadbalancer", "error", err, "messageID", msg.ID(), "subjectID", m.SubjectID.String())
+				s.Logger.Errorw("unable to initialize loadbalancer",
+					"eventType", m.EventType,
+					"error", err,
+					"messageID", msg.ID(),
+					"subjectID", m.SubjectID.String(),
+					"additionalSubjects", m.AdditionalSubjectIDs)
 			}
 		}
 

--- a/internal/srv/handlers_test.go
+++ b/internal/srv/handlers_test.go
@@ -10,8 +10,8 @@ import (
 
 	lbapi "go.infratographer.com/load-balancer-api/pkg/client"
 
-	"go.infratographer.com/loadbalanceroperator/internal/utils"
-	"go.infratographer.com/loadbalanceroperator/internal/utils/mock"
+	"go.infratographer.com/load-balancer-operator/internal/utils"
+	"go.infratographer.com/load-balancer-operator/internal/utils/mock"
 
 	"go.infratographer.com/x/echox"
 	"go.infratographer.com/x/events"
@@ -134,7 +134,7 @@ func (suite *srvTestSuite) TestProcessChange() { //nolint:govet
 		utils.ErrPanic("unable to publish message -3", err)
 	}
 
-	//TODO: verify some update exists
+	// TODO: verify some update exists
 
 	_, err = srv.EventsConnection.PublishChange(context.TODO(), "load-balancer", events.ChangeMessage{
 		EventType:            string(events.DeleteChangeType),

--- a/internal/srv/helm_test.go
+++ b/internal/srv/helm_test.go
@@ -16,7 +16,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli/values"
 	"k8s.io/client-go/rest"
 
-	"go.infratographer.com/loadbalanceroperator/internal/utils/mock"
+	"go.infratographer.com/load-balancer-operator/internal/utils/mock"
 )
 
 // var (

--- a/internal/srv/load-balancer_test.go
+++ b/internal/srv/load-balancer_test.go
@@ -8,15 +8,13 @@ import (
 
 	lbapi "go.infratographer.com/load-balancer-api/pkg/client"
 
-	"go.infratographer.com/loadbalanceroperator/internal/utils/mock"
+	"go.infratographer.com/load-balancer-operator/internal/utils/mock"
 
 	"go.infratographer.com/x/gidx"
 	"go.uber.org/zap"
 )
 
-var (
-	dummyLB = gidx.MustNewID("loadbal")
-)
+var dummyLB = gidx.MustNewID("loadbal")
 
 func (suite *srvTestSuite) TestGetLBFromAddSubjs() { //nolint:govet
 	type testCase struct {

--- a/internal/srv/server.go
+++ b/internal/srv/server.go
@@ -15,7 +15,7 @@ import (
 )
 
 // instrumentationName is a unique package name used for tracing
-const instrumentationName = "go.infratographer.com/loadbalanceroperator/srv"
+const instrumentationName = "go.infratographer.com/load-balancer-operator/srv"
 
 // Server holds options for server connectivity and settings
 type Server struct {

--- a/internal/srv/server_test.go
+++ b/internal/srv/server_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	lbapi "go.infratographer.com/load-balancer-api/pkg/client"
 
-	"go.infratographer.com/loadbalanceroperator/internal/utils"
-	"go.infratographer.com/loadbalanceroperator/internal/utils/mock"
+	"go.infratographer.com/load-balancer-operator/internal/utils"
+	"go.infratographer.com/load-balancer-operator/internal/utils/mock"
 
 	"go.infratographer.com/x/echox"
 	"go.infratographer.com/x/gidx"

--- a/internal/srv/srv_test.go
+++ b/internal/srv/srv_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"go.infratographer.com/loadbalanceroperator/internal/utils"
+	"go.infratographer.com/load-balancer-operator/internal/utils"
 )
 
 func TestSrvTestSuite(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "go.infratographer.com/loadbalanceroperator/cmd"
+import "go.infratographer.com/load-balancer-operator/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
go-releaser appears to have changed the default `.ProjectName` it builds to using the module name in go.mod which has broken the `main-latest` docker [builds](https://github.com/infratographer/load-balancer-operator/actions/workflows/image-main-latest.yml).

Also added additionalSubjects to the process handler logging.