### PR TITLE
Adds dropped logic to continue to process delete events for non-lb ob…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # binary
-loadbalanceroperator
+load-balancer-operator
+
 
 # commonly used files that we don't want ending up in our repo
 kubeconfig

--- a/internal/srv/handlers.go
+++ b/internal/srv/handlers.go
@@ -128,7 +128,7 @@ func prepareLoadBalancer[M Message](ctx context.Context, msg M, s *Server) (*loa
 		// TODO: this is a hack to get around the fact that we can't lookup a loadbalancer
 		// that has already been deleted. So if we have a delete event, we just grab the LB ID
 		// from the message and don't attempt to look it up as we don't need the actual data.
-		if msg.GetEventType() == string(events.DeleteChangeType) {
+		if msg.GetEventType() == string(events.DeleteChangeType) && msg.GetSubject().Prefix() == LBPrefix {
 			lb.isLoadBalancer(msg.GetSubject(), msg.GetAddSubjects())
 
 			span.SetAttributes(attribute.Bool("lbdata-lookup", false))

--- a/internal/srv/helm.go
+++ b/internal/srv/helm.go
@@ -33,7 +33,7 @@ func (v helmvalues) generateLBHelmVals(lb *loadBalancer, s *Server) {
 
 	// add IP address if it is available; will be empty if an IP is not yet assigned
 	// while multiple addresses are possible, we only support one for now
-	if len(lb.lbData.IPAddresses) > 0 {
+	if lb.lbData.IPAddresses != nil && len(lb.lbData.IPAddresses) > 0 {
 		v.StringValues = append(v.StringValues, fmt.Sprintf("%s=%s", managedHelmKeyPrefix+".lbIP", lb.lbData.IPAddresses[0].IP))
 	}
 

--- a/internal/srv/task.go
+++ b/internal/srv/task.go
@@ -2,6 +2,11 @@ package srv
 
 import (
 	"context"
+	"time"
+)
+
+const (
+	lbCleanupCooldown = 5
 )
 
 // runner is a struct that manages the flow of messages for a given loadbalancer
@@ -41,6 +46,13 @@ func (r *runner) run() {
 	for {
 		select {
 		case <-r.quit:
+			for {
+				if len(r.buffer) == 0 {
+					time.Sleep(lbCleanupCooldown * time.Second)
+					break
+				}
+			}
+
 			return
 		default:
 			if len(r.buffer) > 0 {

--- a/internal/srv/task.go
+++ b/internal/srv/task.go
@@ -2,11 +2,6 @@ package srv
 
 import (
 	"context"
-	"time"
-)
-
-const (
-	lbCleanupCooldown = 5
 )
 
 // runner is a struct that manages the flow of messages for a given loadbalancer
@@ -46,13 +41,6 @@ func (r *runner) run() {
 	for {
 		select {
 		case <-r.quit:
-			for {
-				if len(r.buffer) == 0 {
-					time.Sleep(lbCleanupCooldown * time.Second)
-					break
-				}
-			}
-
 			return
 		default:
 			if len(r.buffer) > 0 {


### PR DESCRIPTION
When cleaning up processing logic, the logic to continue to process deleted non-loadbalancer objects was missed, which has resulted in the operator crashing. This PR adds this back in and adds a few other safety checks in to ensure that messages are processed cleanly.