### PR TITLE
Use lbID from event message

### DIFF
--- a/internal/srv/handlers.go
+++ b/internal/srv/handlers.go
@@ -106,7 +106,7 @@ func (s *Server) checkChannel(ctx context.Context, lb *loadBalancer) *runner {
 
 		r := NewRunner(ctx, process)
 
-		s.LoadBalancers[lb.lbData.ID] = r
+		s.LoadBalancers[lb.loadBalancerID.String()] = r
 		ch = r
 	} else {
 		span.SetAttributes(attribute.Bool("channel-exists", true))


### PR DESCRIPTION
lbdata can be nil in `checkChannel`. Use the id from the event