### PR TITLE
Add guard on create deployment if lb location is in operator watched locations

### DIFF
--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/lestrrat-go/backoff/v2"
 	"go.opentelemetry.io/otel"
 	"helm.sh/helm/v3/pkg/action"
@@ -25,8 +27,8 @@ const (
 
 func (s *Server) removeNamespace(ctx context.Context, ns string) error {
 	s.Logger.Debugw("removing namespace", "namespace", ns)
-	kc, err := kubernetes.NewForConfig(s.KubeClient)
 
+	kc, err := kubernetes.NewForConfig(s.KubeClient)
 	if err != nil {
 		s.Logger.Debugw("unable to authenticate against kubernetes cluster", "error", err)
 		return err
@@ -63,8 +65,10 @@ func (s *Server) CreateNamespace(ctx context.Context, hash string) (*v1.Namespac
 		},
 		ObjectMetaApplyConfiguration: &applymetav1.ObjectMetaApplyConfiguration{
 			Name: &hash,
-			Labels: map[string]string{"com.infratographer.lb-operator/managed": "true",
-				"com.infratographer.lb-operator/lb-id": hash},
+			Labels: map[string]string{
+				"com.infratographer.lb-operator/managed": "true",
+				"com.infratographer.lb-operator/lb-id":   hash,
+			},
 		},
 		Spec:   &applyv1.NamespaceSpecApplyConfiguration{},
 		Status: &applyv1.NamespaceStatusApplyConfiguration{},
@@ -104,7 +108,6 @@ func attachRoleBinding(ctx context.Context, client *kubernetes.Clientset, namesp
 	}
 
 	_, err := client.RbacV1().RoleBindings(namespace).Apply(ctx, &apSpec, metav1.ApplyOptions{FieldManager: "loadbalanceroperator"})
-
 	if err != nil {
 		return err
 	}
@@ -248,6 +251,11 @@ func hashLBName(name string) string {
 }
 
 func (s *Server) createDeployment(ctx context.Context, lb *loadBalancer) error {
+	if !slices.Contains(s.Locations, lb.lbData.Location.ID) {
+		s.Logger.Warn("loadbalancer location is not in operator locations, skipping...", "location", lb.lbData.Location, "loadBalancer", lb.loadBalancerID)
+		return nil
+	}
+
 	hash := hashLBName(lb.loadBalancerID.String())
 
 	releaseName := fmt.Sprintf("lb-%s", hash)

--- a/internal/srv/app.go
+++ b/internal/srv/app.go
@@ -252,7 +252,7 @@ func hashLBName(name string) string {
 
 func (s *Server) createDeployment(ctx context.Context, lb *loadBalancer) error {
 	if !slices.Contains(s.Locations, lb.lbData.Location.ID) {
-		s.Logger.Warn("loadbalancer location is not in operator locations, skipping...", "location", lb.lbData.Location, "loadBalancer", lb.loadBalancerID)
+		s.Logger.Warn("load-balancer location not found in operator watch locations, skipping...", "location", lb.lbData.Location.ID, "loadBalancer", lb.loadBalancerID)
 		return nil
 	}
 

--- a/internal/srv/changes_test.go
+++ b/internal/srv/changes_test.go
@@ -61,6 +61,7 @@ func (suite *srvTestSuite) TestProcessLoadBalancerChangeCreate() { //nolint:gove
 		ChartPath:     cp,
 		ValuesPath:    pwd + "/../../hack/ci/values.yaml",
 		LoadBalancers: make(map[string]*runner),
+		Locations:     []string{"lctnloc-testing"},
 	}
 
 	testCases := []testCase{
@@ -70,8 +71,9 @@ func (suite *srvTestSuite) TestProcessLoadBalancerChangeCreate() { //nolint:gove
 			cfg:            suite.Kubeenv.Config,
 			chart:          ch,
 			msg: pubsubx.ChangeMessage{
-				EventType: "create",
-				SubjectID: "loadbal-lkjasdlfkjasdf",
+				EventType:            "create",
+				SubjectID:            "loadbal-lkjasdlfkjasdf",
+				AdditionalSubjectIDs: []gidx.PrefixedID{"lctnloc-testing"},
 			},
 		},
 		{
@@ -80,8 +82,9 @@ func (suite *srvTestSuite) TestProcessLoadBalancerChangeCreate() { //nolint:gove
 			chart:          ch,
 			cfg:            suite.Kubeenv.Config,
 			msg: pubsubx.ChangeMessage{
-				EventType: "create",
-				SubjectID: "loadbal-reallyreallyreallyreallyreallyreallylongreallylong",
+				EventType:            "create",
+				SubjectID:            "loadbal-reallyreallyreallyreallyreallyreallylongreallylong",
+				AdditionalSubjectIDs: []gidx.PrefixedID{"lctnloc-testing"},
 			},
 		},
 	}
@@ -234,6 +237,7 @@ func (suite *srvTestSuite) TestProcessLoadBalancerUpdate() { //nolint:govet
 		ChangeTopics:  []string{"foo", "bar"},
 		ChartPath:     cp,
 		ValuesPath:    pwd + "/../../hack/ci/values.yaml",
+		Locations:     []string{"lctnloc-testing"},
 	}
 
 	id := gidx.MustNewID("loadbal")

--- a/internal/utils/mock/mock.go
+++ b/internal/utils/mock/mock.go
@@ -15,6 +15,9 @@ func DummyAPI(id string) *httptest.Server {
 			"data": {
 				"loadBalancer": {
 				  "id": "%s",
+				  "location": {
+					"id": "lctnloc-testing"
+				  },
 				  "name": "a-very-nice-lb",
 				  "ports": {
 					"edges": [


### PR DESCRIPTION
Defensively coding to prevent this. Common when loadbalancers deployed in multiple locations are using the same `pool`.