### PR TITLE
Bump to go 1.22; fix make unit-tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.22
 
 FROM nats:latest as NATS
 
 FROM mcr.microsoft.com/vscode/devcontainers/go:1-${GO_VERSION}-bullseye
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && \
-    apt-get -y install --no-install-recommends bash-completion 
+    apt-get -y install --no-install-recommends bash-completion
 
 RUN mkdir /opt/nats/ && \
     ln -s /opt/nats/nats-server /usr/local/bin/nats-server
@@ -18,6 +18,7 @@ ARG KIND_CLI_VERSION=0.17.0
 
 RUN go install github.com/nats-io/natscli/nats@v$NATS_CLI_VERSION && \
     go install sigs.k8s.io/kind@v$KIND_CLI_VERSION && \
+    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && \
     chmod -R a+w /go/pkg
 
 ARG HAPROXY_VERSION=0.6.4

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-     
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
 
-      - uses: tylerauerbeck/envtest-action@main
+      - uses: rizzza/envtest-action@patch-1
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s-version }}
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.22
 
 FROM mcr.microsoft.com/vscode/devcontainers/go:1-${GO_VERSION}-bullseye
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PHONY: help all tests coverage lint golint clean binary go-run vendor unit-tests
 GOOS=linux
 
 APP_NAME=loadbalanceroperator
+KUBERNETES_VERSION=1.27
 
 help: Makefile ## Print help
 	@grep -h "##" $(MAKEFILE_LIST) | grep -v grep | sed -e 's/:.*##/#/' | column -c 2 -t -s#
@@ -13,7 +14,7 @@ tests: | unit-tests
 unit-tests: ## Runs unit tests
 	@echo --- Running unit tests...
 	@date -Iseconds
-	@go test -race -cover -failfast -tags testtools -p 1 -v ./...
+	KUBEBUILDER_ASSETS=$(shell setup-envtest use ${KUBERNETES_VERSION} -p path) go test -race -cover -failfast -tags testtools -p 1 -v ./...
 
 coverage: ## Generates coverage report
 	@echo --- Generating coverage report...

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.17.0 // indirect
+	github.com/prometheus/client_golang v1.17.0
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
@@ -155,6 +155,7 @@ require (
 
 require (
 	github.com/gobuffalo/packr/v2 v2.8.3
+	github.com/hasura/go-graphql-client v0.10.0
 	github.com/labstack/echo/v4 v4.11.3
 	go.infratographer.com/ipam-api v0.0.4
 	go.infratographer.com/load-balancer-api v0.0.36-0.20231201160449-63fdc7abfac5
@@ -174,7 +175,6 @@ require (
 	github.com/gobwas/ws v1.0.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1 // indirect
-	github.com/hasura/go-graphql-client v0.10.0 // indirect
 	github.com/lestrrat-go/option v1.0.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.infratographer.com/load-balancer-operator
 
-go 1.21
+go 1.22
 
 replace (
 	github.com/docker/cli => github.com/docker/cli v20.10.19+incompatible


### PR DESCRIPTION
# Summary

- [x] Use go 1.22
- [x] Install `envtest` in devcontainer
- [x] kube envtest requires go 1.22 to download latest go binary in devcontainer

## Test
make unit-tests